### PR TITLE
[캘린더 페이지] 31일 디자인 다른 것 반영

### DIFF
--- a/public/assets/calendar/triangle.svg
+++ b/public/assets/calendar/triangle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="37" viewBox="0 0 180 37" fill="none">
+<path d="M177.374 0.500011L90.2484 36.4593L2.53769 0.499999L177.374 0.500011Z" stroke="#FFFCFA"/>
+</svg>

--- a/public/assets/calendar/triangle.svg
+++ b/public/assets/calendar/triangle.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="180" height="37" viewBox="0 0 180 37" fill="none">
-<path d="M177.374 0.500011L90.2484 36.4593L2.53769 0.499999L177.374 0.500011Z" stroke="#FFFCFA"/>
+  <path d="M2.53769 0.5L90.2484 36.4593L177.374 0.5" stroke="#FFFCFA" stroke-width="0.5"/>
 </svg>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,7 @@ import Guest from './pages/guest/Guest';
 import CalendarPage from './pages/main/CalendarPage';
 import RecordFormAfter from './pages/RecordComplete/RecordFormAfter';
 import GuestFormAfter from './pages/RecordComplete/GuestFormAfter';
-import CalendarDetail from './pages/RecordComplete/CalendarDetail';
+// import CalendarDetail from './pages/RecordComplete/CalendarDetail'; // 파일을 못찾는다는 에러가 떠서 임시 주석처리했습니다.
 import dayjs from 'dayjs';
 import 'dayjs/locale/ko';
 import utc from 'dayjs/plugin/utc';
@@ -57,7 +57,10 @@ function App() {
                         path='/mycomplete/:userId'
                         element={<MyCreationComplete />}
                     />
-                     <Route path="/calendar-detail/:userId" element={<CalendarDetail />} />
+                    {/* <Route
+                        path='/calendar-detail/:userId'
+                        element={<CalendarDetail />}
+                    /> */}
                     <Route path='*' element={<div>Not Found</div>} />
                 </Routes>
             </Router>

--- a/src/pages/main/Calendar/Calendar.jsx
+++ b/src/pages/main/Calendar/Calendar.jsx
@@ -28,7 +28,7 @@ export const isRecordable = (year, time) => {
 const Calendar = ({ serverTime, hasWritten, year }) => {
     const today = dayjs(serverTime);
 
-    const recordable = isRecordable(serverTime, year);
+    const recordable = isRecordable(year, serverTime);
 
     const lastDayWritten = hasWritten[31];
 

--- a/src/pages/main/Calendar/Day.jsx
+++ b/src/pages/main/Calendar/Day.jsx
@@ -26,7 +26,7 @@ const containerStyle = {
 
 const dayButtonStyle = {
     width: '100%',
-    px: '6px',
+    p: 0,
     boxSizing: 'border-box',
 };
 
@@ -74,7 +74,7 @@ const Day = ({
     };
     let color = theme.palette.custom.white;
     let imgDisplay = false;
-    let triangleDisplay = 'none';
+    let triangleDisplay = false;
 
     // 기록 작성 가능 기간: 11월 30일 ~ 12월 31일 (범위 내)
     if (recordable) {
@@ -91,7 +91,7 @@ const Day = ({
         } else if (currentDay.isAfter(today)) {
             // 미래 날짜
             style.border = `1px solid ${theme.palette.custom.white}`;
-            if (date === 31) triangleDisplay = 'block';
+            if (date === 31) triangleDisplay = true;
         } else {
             // 지나간 날짜 작성 안함
             style.backgroundColor = 'rgba(255, 252, 250, 0.1)';
@@ -132,8 +132,7 @@ const Day = ({
                     ...dayButtonStyle,
                 }}
                 justifyContent={
-                    styleConfig.position === 'middle' &&
-                    triangleDisplay === 'none'
+                    styleConfig.position === 'middle' && !triangleDisplay
                         ? 'center'
                         : 'flex-start'
                 }
@@ -150,7 +149,9 @@ const Day = ({
                 <img
                     src={`/assets/calendar/triangle.svg`}
                     style={{
-                        display: triangleDisplay,
+                        display: triangleDisplay ? 'block' : 'none',
+                        width: '100%',
+                        transform: 'translateY(-1px)',
                         ...triangleStyle,
                     }}
                 />
@@ -158,9 +159,10 @@ const Day = ({
                     sx={{
                         color: color,
                         pointerEvents: 'none',
-                        marginTop: triangleDisplay === 'block' ? '3px' : 0,
+                        transform: triangleDisplay ? 'translateY(3px)' : 0,
+                        mx: '6px',
                     }}
-                    variant={styleConfig.variant}
+                    variant={triangleDisplay ? 'number2' : styleConfig.variant}
                 >
                     {date ? date : '11.30'}
                 </Typography>

--- a/src/pages/main/Calendar/Day.jsx
+++ b/src/pages/main/Calendar/Day.jsx
@@ -11,6 +11,35 @@ dayjs.extend(isSameOrAfter);
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
+const containerStyle = {
+    boxSizing: 'border-box',
+    width: '100%',
+    height: 'auto',
+    minWidth: 0,
+    minHeight: 0,
+    backgroundSize: 'cover',
+    backgroundPosition: 'center',
+    backgroundBlendMode: 'overlay',
+    overflow: 'hidden',
+    position: 'relative',
+};
+
+const dayButtonStyle = {
+    width: '100%',
+    px: '6px',
+    boxSizing: 'border-box',
+};
+
+const triangleStyle = {
+    width: '100%',
+    aspectRatio: '180.5/37',
+    position: 'absolute',
+    top: '0',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    pointerEvents: 'none',
+};
+
 // 스타일 및 날짜 관련 설정 추상화
 const Day = ({
     time,
@@ -85,34 +114,22 @@ const Day = ({
     return (
         <Stack
             sx={{
-                boxSizing: 'border-box',
-                width: '100%',
-                height: 'auto',
-                minWidth: 0,
-                minHeight: 0,
                 backgroundImage: imgDisplay
                     ? `url("/assets/calendar/puzzle_${date}.svg")`
                     : 'none',
-                backgroundSize: 'cover',
-                backgroundPosition: 'center',
                 backgroundColor: style.backgroundColor,
-                backgroundBlendMode: 'overlay',
-                overflow: 'hidden',
+                ...containerStyle,
                 ...styleConfig.boxStyle,
-                position: 'relative',
             }}
             justifyContent={'center'}
             alignItems={'center'}
         >
-            <Stack
+            <Stack // 이 스택 컴포넌트가 실질적으로 버튼 역할을 합니다.
                 sx={{
-                    zIndex: 1,
-                    width: '100%',
-                    px: '6px',
-                    boxSizing: 'border-box',
                     border: style.border,
                     backgroundColor: `${style.backgroundColor} !important`,
                     ...styleConfig.boxStyle,
+                    ...dayButtonStyle,
                 }}
                 justifyContent={
                     styleConfig.position === 'middle' &&
@@ -127,21 +144,14 @@ const Day = ({
                           ? 'end'
                           : 'start'
                 }
-                component={Button}
+                component={Button} //
                 disabled={recordable || !lastDayWritten}
             >
-                <Box
-                    component={'img'}
+                <img
                     src={`/assets/calendar/triangle.svg`}
-                    sx={{
+                    style={{
                         display: triangleDisplay,
-                        width: '100%',
-                        aspectRatio: '180.5/37',
-                        position: 'absolute',
-                        top: '0',
-                        left: '50%',
-                        transform: 'translateX(-50%)',
-                        pointerEvents: 'none',
+                        ...triangleStyle,
                     }}
                 />
                 <Typography

--- a/src/pages/main/Calendar/Day.jsx
+++ b/src/pages/main/Calendar/Day.jsx
@@ -1,4 +1,4 @@
-import { Stack, Typography, useTheme } from '@mui/material';
+import { Box, Stack, Typography, useTheme } from '@mui/material';
 import { Button } from '@mui/base';
 import React from 'react';
 import dayjs from 'dayjs';
@@ -21,13 +21,6 @@ const Day = ({
     recordable,
     year,
 }) => {
-    console.log('time', time);
-    console.log('hasWritten', hasWritten);
-    console.log('date', date);
-    console.log('styleConfig', styleConfig);
-    console.log('lastDayWritten', lastDayWritten);
-    console.log('recordable', recordable);
-    console.log('year', year);
     /*
         20xx-11-30 ~ 20xx-12-31: 작성 가능
         20xx-12-31             : 작성 완료 시 캘린더를 볼 수 있음 
@@ -52,6 +45,7 @@ const Day = ({
     };
     let color = theme.palette.custom.white;
     let imgDisplay = false;
+    let triangleDisplay = 'none';
 
     // 기록 작성 가능 기간: 11월 30일 ~ 12월 31일 (범위 내)
     if (recordable) {
@@ -68,6 +62,7 @@ const Day = ({
         } else if (currentDay.isAfter(today)) {
             // 미래 날짜
             style.border = `1px solid ${theme.palette.custom.white}`;
+            if (date === 31) triangleDisplay = 'block';
         } else {
             // 지나간 날짜 작성 안함
             style.backgroundColor = 'rgba(255, 252, 250, 0.1)';
@@ -104,6 +99,7 @@ const Day = ({
                 backgroundBlendMode: 'overlay',
                 overflow: 'hidden',
                 ...styleConfig.boxStyle,
+                position: 'relative',
             }}
             justifyContent={'center'}
             alignItems={'center'}
@@ -119,7 +115,10 @@ const Day = ({
                     ...styleConfig.boxStyle,
                 }}
                 justifyContent={
-                    styleConfig.position === 'middle' ? 'center' : 'flex-start'
+                    styleConfig.position === 'middle' &&
+                    triangleDisplay === 'none'
+                        ? 'center'
+                        : 'flex-start'
                 }
                 alignItems={
                     styleConfig.position === 'middle'
@@ -131,10 +130,25 @@ const Day = ({
                 component={Button}
                 disabled={recordable || !lastDayWritten}
             >
+                <Box
+                    component={'img'}
+                    src={`/assets/calendar/triangle.svg`}
+                    sx={{
+                        display: triangleDisplay,
+                        width: '100%',
+                        aspectRatio: '180.5/37',
+                        position: 'absolute',
+                        top: '0',
+                        left: '50%',
+                        transform: 'translateX(-50%)',
+                        pointerEvents: 'none',
+                    }}
+                />
                 <Typography
                     sx={{
                         color: color,
                         pointerEvents: 'none',
+                        marginTop: triangleDisplay === 'block' ? '3px' : 0,
                     }}
                     variant={styleConfig.variant}
                 >

--- a/src/pages/main/Calendar/Day.jsx
+++ b/src/pages/main/Calendar/Day.jsx
@@ -21,6 +21,13 @@ const Day = ({
     recordable,
     year,
 }) => {
+    console.log('time', time);
+    console.log('hasWritten', hasWritten);
+    console.log('date', date);
+    console.log('styleConfig', styleConfig);
+    console.log('lastDayWritten', lastDayWritten);
+    console.log('recordable', recordable);
+    console.log('year', year);
     /*
         20xx-11-30 ~ 20xx-12-31: 작성 가능
         20xx-12-31             : 작성 완료 시 캘린더를 볼 수 있음 

--- a/src/pages/main/Calendar/Day.jsx
+++ b/src/pages/main/Calendar/Day.jsx
@@ -1,4 +1,4 @@
-import { Box, Stack, Typography, useTheme } from '@mui/material';
+import { Stack, Typography, useTheme } from '@mui/material';
 import { Button } from '@mui/base';
 import React from 'react';
 import dayjs from 'dayjs';

--- a/src/pages/main/CalendarPage.jsx
+++ b/src/pages/main/CalendarPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import Calendar from './Calendar/Calendar';
 import Layout from '@/layouts/Layout';
@@ -21,11 +21,7 @@ const CalendarPage = () => {
     const fetcher = (url) =>
         axiosWithAuth.get(url).then((res) => res.data.result);
 
-    const { data, isLoading } = useSWR(`/calendar/data`, fetcher, {
-        onError: (error) => {
-            console.log(error);
-        },
-    });
+    const { data, isLoading } = useSWR(`/calendar/data`, fetcher);
 
     const handleClose = () => {
         navigate(-1);
@@ -44,7 +40,6 @@ const CalendarPage = () => {
 
     const lastDayWritten = data.writtenArray[31];
 
-    console.log(!isRecordable(data.serverTime, year) || lastDayWritten);
     return (
         <Layout
             snow

--- a/src/pages/main/CalendarPage.jsx
+++ b/src/pages/main/CalendarPage.jsx
@@ -21,7 +21,11 @@ const CalendarPage = () => {
     const fetcher = (url) =>
         axiosWithAuth.get(url).then((res) => res.data.result);
 
-    const { data, isLoading } = useSWR(`/calendar/data`, fetcher);
+    const { data, isLoading } = useSWR(`/calendar/data`, fetcher, {
+        onError: (error) => {
+            console.error(error);
+        },
+    });
 
     const handleClose = () => {
         navigate(-1);
@@ -38,7 +42,7 @@ const CalendarPage = () => {
 
     if (isLoading) return <Loading />;
 
-    const lastDayWritten = data.writtenArray[31];
+    const lastDayWritten = data.written_array[31];
 
     return (
         <Layout
@@ -77,7 +81,7 @@ const CalendarPage = () => {
                     spacing={0.75}
                 >
                     <Typography variant='title3' sx={{ color: 'custom.grey' }}>
-                        {!isRecordable(data.serverTime) || lastDayWritten
+                        {!isRecordable(data.server_time) || lastDayWritten
                             ? '추억이 완성되었습니다!'
                             : '당신의 추억을 모아 퍼즐을 완성하세요!'}
                     </Typography>
@@ -91,16 +95,16 @@ const CalendarPage = () => {
                             component={'span'}
                             sx={{ color: 'custom.main1' }}
                         >
-                            {`${data.myMemoryCount}개`}
+                            {`${data.my_memory_count}개`}
                         </Typography>
                     </Typography>
                 </Stack>
                 <Calendar
-                    serverTime={data.serverTime}
-                    hasWritten={data.writtenArray}
+                    serverTime={data.server_time}
+                    hasWritten={data.written_array}
                     year={year}
                 />
-                {(!isRecordable(data.serverTime) || lastDayWritten) && (
+                {(!isRecordable(data.server_time) || lastDayWritten) && (
                     <Button
                         variant='contained'
                         sx={{

--- a/src/storybook/pages/main/Calendar.stories.jsx
+++ b/src/storybook/pages/main/Calendar.stories.jsx
@@ -10,6 +10,9 @@ const meta = {
         hasWritten: {
             control: 'array',
         },
+        year: {
+            control: 'number',
+        },
     },
 };
 
@@ -18,24 +21,29 @@ export default meta;
 const allWritten = {
     serverTime: '2024-12-31',
     hasWritten: Array(32).fill(true).fill(false, 31),
+    year: 2024,
 };
 const noWritten = {
     serverTime: '2024-12-31',
     hasWritten: Array(32).fill(false),
+    year: 2024,
 };
 const someWritten = {
     serverTime: '2024-12-31',
     hasWritten: Array(32).fill(false).fill(true, 15, 20),
+    year: 2024,
 };
 
 const firstDay = {
     serverTime: '2024-11-30',
     hasWritten: Array(32).fill(false),
+    year: 2024,
 };
 
 const lastDayWritten = {
     serverTime: '2024-12-31',
     hasWritten: Array(32).fill(true),
+    year: 2024,
 };
 
 const FirstDay = {

--- a/src/storybook/pages/main/Day.stories.jsx
+++ b/src/storybook/pages/main/Day.stories.jsx
@@ -1,5 +1,6 @@
 import Day from '@/pages/main/Calendar/Day';
 import dayjs from 'dayjs';
+import { LastDayWritten } from './Calendar.stories';
 
 const meta = {
     title: 'main/Day',
@@ -14,6 +15,22 @@ const meta = {
         date: {
             control: 'number',
             description: '오늘 날짜, 0일 경우 11월 30일로 처리',
+        },
+        styleConfig: {
+            control: 'object',
+            description: '스타일 설정',
+        },
+        lastDayWritten: {
+            control: 'boolean',
+            description: '마지막 날 작성 여부',
+        },
+        recordable: {
+            control: 'boolean',
+            description: '기록 가능 여부',
+        },
+        year: {
+            control: 'number',
+            description: '년도',
         },
     },
 };
@@ -32,11 +49,27 @@ const styleConfig = {
 };
 
 export const TodayNotWritten = () => (
-    <Day time={today} hasWritten={false} date={1} styleConfig={styleConfig} />
+    <Day
+        time={today}
+        hasWritten={false}
+        date={1}
+        styleConfig={styleConfig}
+        lastDayWritten={false}
+        recordable={true}
+        year={2024}
+    />
 );
 
 export const TodayWritten = () => (
-    <Day time={today} hasWritten={true} date={1} styleConfig={styleConfig} />
+    <Day
+        time={today}
+        hasWritten={true}
+        date={1}
+        styleConfig={styleConfig}
+        lastDayWritten={false}
+        recordable={true}
+        year={2024}
+    />
 );
 
 export const Future = () => (
@@ -45,6 +78,9 @@ export const Future = () => (
         hasWritten={false}
         date={1}
         styleConfig={styleConfig}
+        lastDayWritten={false}
+        recordable={true}
+        year={2024}
     />
 );
 
@@ -54,6 +90,9 @@ export const PastNotWritten = () => (
         hasWritten={false}
         date={1}
         styleConfig={styleConfig}
+        lastDayWritten={false}
+        recordable={true}
+        year={2024}
     />
 );
 
@@ -63,6 +102,9 @@ export const PastWritten = () => (
         hasWritten={true}
         date={1}
         styleConfig={styleConfig}
+        lastDayWritten={false}
+        recordable={true}
+        year={2024}
     />
 );
 
@@ -72,6 +114,9 @@ export const AfterEventNotWritten = () => (
         hasWritten={false}
         date={1}
         styleConfig={styleConfig}
+        lastDayWritten={false}
+        recordable={false}
+        year={2024}
     />
 );
 
@@ -81,6 +126,9 @@ export const AfterEventWritten = () => (
         hasWritten={true}
         date={1}
         styleConfig={styleConfig}
+        lastDayWritten={false}
+        recordable={false}
+        year={2024}
     />
 );
 
@@ -90,6 +138,9 @@ export const MiddleAligned = () => (
         hasWritten={false}
         date={1}
         styleConfig={{ ...styleConfig, position: 'middle' }}
+        lastDayWritten={false}
+        recordable={true}
+        year={2024}
     />
 );
 
@@ -99,6 +150,9 @@ export const RightAligned = () => (
         hasWritten={false}
         date={1}
         styleConfig={{ ...styleConfig, position: 'right', variant: 'number2' }}
+        lastDayWritten={false}
+        recordable={true}
+        year={2024}
     />
 );
 


### PR DESCRIPTION
### 구현 사항
1. 31일 디자인이 다른 것을 반영하였습니다.
2. 지저분한 스타일 코드를 따로 뺐습니다. 
<img width="264" alt="스크린샷 2024-10-30 오전 12 08 22" src="https://github.com/user-attachments/assets/fc82564e-c7a2-432e-889c-98ba28e8c405">
