### PR TITLE
[메인 페이지] 질문 404에러 못 잡는 현상 수정

### DIFF
--- a/src/pages/main/Main.jsx
+++ b/src/pages/main/Main.jsx
@@ -153,7 +153,8 @@ const Main = () => {
         questionFetcher,
         {
             onError: (error) => {
-                if (error.status === 400) setHasWritten(true);
+                if (error.status === 400 || error.status === 404)
+                    setHasWritten(true);
             },
             revalidateOnMount: true,
             revalidateOnFocus: false,


### PR DESCRIPTION
### 수정 사항
- 오늘의 질문 api가 404에러를 리턴할 경우 500에러 페이지로 넘어가는 현상을 수정하였습니다.