### PR TITLE
[메인 페이지] UTC타임스탬프 처리 안되어있는 현상 수정

### DIFF
--- a/src/pages/main/Main.jsx
+++ b/src/pages/main/Main.jsx
@@ -140,7 +140,7 @@ const Main = () => {
             .then((res) => res.data.result)
             .then((data) => {
                 setHasWritten(false);
-                const dateObj = dayjs(data.date);
+                const dateObj = dayjs.utc(data.date).tz('Asia/Seoul');
                 const formattedDate = dateObj.format(`MM월 DD일`);
                 localStorage.setItem('dailyQuestion', data.question);
                 localStorage.setItem('dailyDate', formattedDate);


### PR DESCRIPTION
### 수정 사항
- utc 타임 스탬프를 받을 때 적용되어야하는 함수가 안되어있는 부분 수정

원래는 main과 guest의 통합을 처리하고 같이 올리려했는데, 백엔드의 확인이 필요하다는 요청에 따라 먼저 올립니다. 