### PR TITLE
[인앱브라우저] 사파리는 그냥 알림창 띄우기

### DIFF
--- a/src/pages/error/InAppBrowserBlocker.jsx
+++ b/src/pages/error/InAppBrowserBlocker.jsx
@@ -14,12 +14,9 @@ const InAppBrowserBlocker = () => {
         if (/android/i.test(navigator.userAgent)) {
             window.location.href = externalURL;
         } else if (/iPad|iPhone|iPod/.test(navigator.userAgent)) {
-            const newWindow = window.open(externalURL, '_blank');
-            if (!newWindow) {
-                alert(
-                    '팝업 차단이 활성화되어 있습니다. Safari 브라우저에서 직접 열어주세요.'
-                );
-            }
+            alert(
+                '팝업 차단이 활성화되어 있습니다. Safari 브라우저에서 직접 열어주세요.'
+            );
         } else {
             window.location.href = externalURL;
         }


### PR DESCRIPTION
사파리에서는 애초에 다른 꼼수가 아니면 강제로 사파리를 열 수 없어서
alert만 띄우도록 했습니다. 계속 새로운창이 열리려고 시도를해서 알림창이 안뜨는 문제가 생겨 수정했습니다.